### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ESPHome component to monitor a AEconversion micro inverter using RS485
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases)
+* [ESPHome 2024.12.0 or higher](https://github.com/esphome/esphome/releases)
 * Generic ESP32 or ESP8266 board
 
 ## Installation

--- a/components/aesgi/__init__.py
+++ b/components/aesgi/__init__.py
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(aesgi_rs485.aesgi_rs485_device_schema(1))
+    .extend(aesgi_rs485.aesgi_rs485_device_schema(1)),
 )
 
 

--- a/components/aesgi/__init__.py
+++ b/components/aesgi/__init__.py
@@ -25,7 +25,8 @@ AESGI_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Aesgi),

--- a/components/aesgi_rs485/__init__.py
+++ b/components/aesgi_rs485/__init__.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/aesgi_rs485/__init__.py
+++ b/components/aesgi_rs485/__init__.py
@@ -13,7 +13,8 @@ AesgiRs485Device = aesgi_rs485_ns.class_("AesgiRs485Device")
 CONF_AESGI_RS485_ID = "aesgi_rs485_id"
 CONF_RX_TIMEOUT = "rx_timeout"
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AesgiRs485),

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-query-data.yaml
+++ b/tests/esp8266-query-data.yaml
@@ -6,7 +6,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.