### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/aesgi/button/__init__.py
+++ b/components/aesgi/button/__init__.py
@@ -23,10 +23,10 @@ CONFIG_SCHEMA = AESGI_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_AUTO_TEST): button.button_schema(
             AesgiButton, icon="mdi:check-circle-outline"
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_OPERATION_MODE_PV): button.button_schema(
             AesgiButton, icon="mdi:solar-power"
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant