### PR TITLE
Add component schema tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -396,6 +396,30 @@ jobs:
         # yamllint disable-line rule:line-length
         if: always()
 
+  pytest:
+    name: Run pytest
+    runs-on: ubuntu-24.04
+    needs:
+      - bundle
+      - common
+    steps:
+      - name: Download prepared repository
+        uses: pyTooling/download-artifact@v4
+        with:
+          name: bundle
+          path: .
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pytest tests/ -v
+
   esphome-config:
     name: Validate example configurations
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,15 @@ repos:
         args: [--persistent=n, components]
         pass_filenames: false
         additional_dependencies: [esphome]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: python
+        types: [python]
+        pass_filenames: false
+        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Mock missing esphome external component dependencies for test collection."""
+
+import sys
+import types
+
+import esphome.codegen as cg
+
+
+def _make_modbus_mock(ns_name, *class_names):
+    """Return a namespace where Device classes are MockObjClass and functions return {}."""
+    _ns = cg.esphome_ns.namespace(f"_mock_{ns_name}")
+    _classes = {name: _ns.class_(name) for name in class_names}
+
+    class _MockModbus:
+        def __getattr__(self, name):
+            if name in _classes:
+                return _classes[name]
+            # Schema functions return empty dict; other callables return MagicMock
+            return lambda *a, **kw: {}
+
+    return _MockModbus()
+
+
+sys.modules["esphome.components.aesgi_rs485"] = _make_modbus_mock(
+    "aesgi_rs485", "AesgiRs485Device"
+)

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -1,0 +1,99 @@
+"""Schema structure tests for aesgi ESPHome component modules."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import components.aesgi as hub  # noqa: E402
+from components.aesgi import (  # noqa: E402
+    binary_sensor,
+    button,  # noqa: E402
+    number,  # noqa: E402
+    sensor,
+    text_sensor,
+)
+
+
+class TestHubConstants:
+    def test_conf_aesgi_id_defined(self):
+        assert hub.CONF_AESGI_ID == "aesgi_id"
+
+
+class TestSensorDefs:
+    def test_sensor_defs_completeness(self):
+        assert "status" in sensor.SENSOR_DEFS
+        assert sensor.CONF_DC_VOLTAGE in sensor.SENSOR_DEFS
+        assert sensor.CONF_DC_CURRENT in sensor.SENSOR_DEFS
+        assert sensor.CONF_AC_VOLTAGE in sensor.SENSOR_DEFS
+        assert sensor.CONF_AC_CURRENT in sensor.SENSOR_DEFS
+        assert sensor.CONF_DEVICE_TEMPERATURE in sensor.SENSOR_DEFS
+        assert len(sensor.SENSOR_DEFS) == 23
+
+    def test_error_history_error_codes_count(self):
+        assert len(sensor.ERROR_HISTORY_ERROR_CODES) == 6
+
+    def test_error_history_error_times_count(self):
+        assert len(sensor.ERROR_HISTORY_ERROR_TIMES) == 6
+
+    def test_error_history_naming(self):
+        assert (
+            sensor.CONF_ERROR_HISTORY_SLOT1_ERROR_CODE
+            == "error_history_slot1_error_code"
+        )
+        assert (
+            sensor.CONF_ERROR_HISTORY_SLOT6_ERROR_CODE
+            == "error_history_slot6_error_code"
+        )
+        assert (
+            sensor.CONF_ERROR_HISTORY_SLOT1_ERROR_TIME
+            == "error_history_slot1_error_time"
+        )
+        assert (
+            sensor.CONF_ERROR_HISTORY_SLOT6_ERROR_TIME
+            == "error_history_slot6_error_time"
+        )
+
+
+class TestBinarySensorDefs:
+    def test_binary_sensor_defs_completeness(self):
+        assert binary_sensor.CONF_BALANCING in binary_sensor.BINARY_SENSOR_DEFS
+        assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 8
+
+    def test_charging_discharging_present(self):
+        from components.aesgi.const import CONF_CHARGING, CONF_DISCHARGING
+
+        assert CONF_CHARGING in binary_sensor.BINARY_SENSOR_DEFS
+        assert CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
+
+
+class TestTextSensors:
+    def test_text_sensors_list(self):
+        assert text_sensor.CONF_ERRORS in text_sensor.TEXT_SENSORS
+        assert text_sensor.CONF_OPERATION_MODE in text_sensor.TEXT_SENSORS
+        assert text_sensor.CONF_DEVICE_TYPE in text_sensor.TEXT_SENSORS
+        assert len(text_sensor.TEXT_SENSORS) == 3
+
+
+class TestButtonConstants:
+    def test_buttons_dict(self):
+        assert button.CONF_AUTO_TEST in button.BUTTONS
+        assert button.CONF_OPERATION_MODE_PV in button.BUTTONS
+        assert len(button.BUTTONS) == 2
+
+    def test_button_addresses_are_unique(self):
+        addresses = list(button.BUTTONS.values())
+        assert len(addresses) == len(set(addresses))
+
+
+class TestNumberConstants:
+    def test_numbers_dict(self):
+        assert number.CONF_OUTPUT_POWER_THROTTLE in number.NUMBERS
+        assert number.CONF_BATTERY_VOLTAGE_LIMIT in number.NUMBERS
+        assert number.CONF_BATTERY_CURRENT_LIMIT in number.NUMBERS
+        assert len(number.NUMBERS) == 4
+
+    def test_number_addresses_are_unique(self):
+        addresses = list(number.NUMBERS.values())
+        assert len(addresses) == len(set(addresses))


### PR DESCRIPTION
## Summary
- Add `tests/test_component_schemas.py` with schema structure tests for all component modules
- Add pytest hook to `.pre-commit-config.yaml`
- Add pytest job to CI workflow

## Test plan
- [x] All existing tests pass
- [x] New pytest job passes in CI