### PR TITLE
Optimize clang-tidy by removing splits, adding incremental scans and fixing platformio cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,6 +312,8 @@ jobs:
     defaults:
       run:
         working-directory: esphome
+    env:
+      GH_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -322,20 +324,8 @@ jobs:
             options: --environment esp8266-arduino-tidy --grep USE_ESP8266
             pio_cache_key: tidyesp8266
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 1/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 2/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 3/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 4/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
+            name: Run script/clang-tidy for ESP32 Arduino
+            options: --environment esp32-arduino-tidy
             pio_cache_key: tidyesp32
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 IDF
@@ -358,18 +348,20 @@ jobs:
           cache-key: ${{ needs.common.outputs.cache-key }}
 
       - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache@v5.0.4
         with:
           path: ~/.platformio
-          key: platformio-${{ matrix.pio_cache_key }}
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-${{ matrix.pio_cache_key }}-
 
       - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
+        if: github.ref != 'refs/heads/main'
         uses: actions/cache/restore@v5.0.4
         with:
           path: ~/.platformio
-          key: platformio-${{ matrix.pio_cache_key }}
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-${{ matrix.pio_cache_key }}-
 
       - name: Register problem matchers
         run: |
@@ -386,7 +378,7 @@ jobs:
       - name: Run clang-tidy
         run: |
           . venv/bin/activate
-          script/clang-tidy --all-headers --fix ${{ matrix.options }} ../components
+          script/clang-tidy --all-headers --fix ${{ matrix.options }} $(ls ../components/)
         env:
           # Also cache libdeps, store them in a ~/.platformio subfolder
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
@@ -474,6 +466,22 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
+      - name: Cache platformio
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache@v5.0.4
+        with:
+          path: ~/.platformio
+          key: platformio-compile-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-compile-
+
+      - name: Cache platformio
+        if: github.ref != 'refs/heads/main'
+        uses: actions/cache/restore@v5.0.4
+        with:
+          path: ~/.platformio
+          key: platformio-compile-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-compile-
+
       - name: Compile example configurations
         run: |
           . venv/bin/activate
@@ -481,6 +489,8 @@ jobs:
           for YAML in esp*.yaml; do
             esphome -s external_components_source components compile $YAML
           done
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
       - name: Compile test configurations
         run: |
@@ -489,3 +499,5 @@ jobs:
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components compile $YAML
           done
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps


### PR DESCRIPTION
## Summary

- Remove ESP32 Arduino clang-tidy splits (4→1 job), reducing CI parallelism overhead
- Add incremental platformio cache with `hashFiles` key and `restore-keys` fallback
- Fix platformio cache branch condition from `dev` to `main`
- Pass `$(ls ../components/)` instead of `../components` for incremental clang-tidy scanning
- Add platformio cache to the compile job
- Set `PLATFORMIO_LIBDEPS_DIR` in compile steps so libdeps land in the cached directory