### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/aesgi/aesgi.cpp
+++ b/components/aesgi/aesgi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace aesgi {
+namespace esphome::aesgi {
 
 static const char *const TAG = "aesgi";
 
@@ -392,5 +391,4 @@ void Aesgi::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_TEXT_SENSOR("", "Device Type", this->device_type_text_sensor_);
 }
 
-}  // namespace aesgi
-}  // namespace esphome
+}  // namespace esphome::aesgi

--- a/components/aesgi/aesgi.h
+++ b/components/aesgi/aesgi.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/aesgi_rs485/aesgi_rs485.h"
 
-namespace esphome {
-namespace aesgi {
+namespace esphome::aesgi {
 
 class Aesgi : public PollingComponent, public aesgi_rs485::AesgiRs485Device {
  public:
@@ -172,5 +171,4 @@ class Aesgi : public PollingComponent, public aesgi_rs485::AesgiRs485Device {
   }
 };
 
-}  // namespace aesgi
-}  // namespace esphome
+}  // namespace esphome::aesgi

--- a/components/aesgi/button/aesgi_button.cpp
+++ b/components/aesgi/button/aesgi_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace aesgi {
+namespace esphome::aesgi {
 
 static const char *const TAG = "aesgi.button";
 
@@ -17,5 +16,4 @@ void AesgiButton::press_action() {
   this->parent_->send(this->holding_register_);
 }
 
-}  // namespace aesgi
-}  // namespace esphome
+}  // namespace esphome::aesgi

--- a/components/aesgi/button/aesgi_button.h
+++ b/components/aesgi/button/aesgi_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace aesgi {
+namespace esphome::aesgi {
 
 class Aesgi;
 class AesgiButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class AesgiButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace aesgi
-}  // namespace esphome
+}  // namespace esphome::aesgi

--- a/components/aesgi/number/aesgi_number.cpp
+++ b/components/aesgi/number/aesgi_number.cpp
@@ -1,8 +1,7 @@
 #include "aesgi_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace aesgi {
+namespace esphome::aesgi {
 
 static const char *const TAG = "aesgi.number";
 
@@ -33,5 +32,4 @@ void AesgiNumber::control(float value) {
   this->publish_state(value);
 }
 
-}  // namespace aesgi
-}  // namespace esphome
+}  // namespace esphome::aesgi

--- a/components/aesgi/number/aesgi_number.h
+++ b/components/aesgi/number/aesgi_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace aesgi {
+namespace esphome::aesgi {
 
 class Aesgi;
 
@@ -22,5 +21,4 @@ class AesgiNumber : public number::Number, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace aesgi
-}  // namespace esphome
+}  // namespace esphome::aesgi

--- a/components/aesgi_rs485/aesgi_rs485.cpp
+++ b/components/aesgi_rs485/aesgi_rs485.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace aesgi_rs485 {
+namespace esphome::aesgi_rs485 {
 
 static const char *const TAG = "aesgi_rs485";
 
@@ -154,5 +153,4 @@ void AesgiRs485::send_broadcast(uint8_t command, const std::string &value) {
   this->flush();
 }
 
-}  // namespace aesgi_rs485
-}  // namespace esphome
+}  // namespace esphome::aesgi_rs485

--- a/components/aesgi_rs485/aesgi_rs485.h
+++ b/components/aesgi_rs485/aesgi_rs485.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace aesgi_rs485 {
+namespace esphome::aesgi_rs485 {
 
 class AesgiRs485Device;
 
@@ -57,5 +56,4 @@ class AesgiRs485Device {
   uint8_t address_;
 };
 
-}  // namespace aesgi_rs485
-}  // namespace esphome
+}  // namespace esphome::aesgi_rs485


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.