### PR TITLE
Add C++ tests for aesgi_rs485

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -550,7 +550,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py aesgi
+          script/cpp_unit_test.py aesgi aesgi_rs485
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/tests/components/aesgi_rs485/aesgi_rs485_test.cpp
+++ b/tests/components/aesgi_rs485/aesgi_rs485_test.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+#include "common.h"
+
+namespace esphome::aesgi_rs485::testing {
+
+// Real captured response from esp8266-inverter-emulator.yaml (address 29):
+// *290   0  20.0  0.00     0 235.1  0.01     1  50     44 \xD9\r
+static const std::string REAL_STATUS_FRAME =
+    "*290   0  20.0  0.00     0 235.1  0.01     1  50     44 \xD9\r";
+
+// verify_checksum_ special case: remote_crc == 0x20 (space) and (crc + 0x20) & 0xFF == '\r'
+// This handles a quirk where the CRC byte is a space followed by a carriage-return-like value.
+
+TEST(VerifyChecksumTest, NormalMatch) {
+  TestableAesgiRs485 bus;
+  EXPECT_TRUE(bus.verify_checksum_(0xAB, 0xAB));
+}
+
+TEST(VerifyChecksumTest, NormalMismatch) {
+  TestableAesgiRs485 bus;
+  EXPECT_FALSE(bus.verify_checksum_(0xAB, 0xCD));
+}
+
+TEST(VerifyChecksumTest, SpaceCrcSpecialCase) {
+  // remote_crc = 0x20, computed_crc such that (computed_crc + 0x20) & 0xFF == '\r' (0x0D)
+  // -> computed_crc = 0x0D - 0x20 = 0xED
+  TestableAesgiRs485 bus;
+  EXPECT_TRUE(bus.verify_checksum_(0xED, 0x20));
+}
+
+TEST(VerifyChecksumTest, SpaceCrcSpecialCaseNoMatch) {
+  TestableAesgiRs485 bus;
+  EXPECT_FALSE(bus.verify_checksum_(0x00, 0x20));
+}
+
+// Frame parsing and device dispatch
+
+TEST(AesgiRs485ParseTest, ValidFrameDispatchedToDevice) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(1);
+  bus.register_device(&device);
+
+  std::string frame = make_frame(1, "X");
+  bus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 1);
+  EXPECT_EQ(device.received_data, frame);
+}
+
+TEST(AesgiRs485ParseTest, RealStatusFrameDispatched) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(29);
+  bus.register_device(&device);
+
+  bus.feed(REAL_STATUS_FRAME);
+
+  EXPECT_EQ(device.call_count, 1);
+  EXPECT_EQ(device.received_data, REAL_STATUS_FRAME);
+}
+
+TEST(AesgiRs485ParseTest, InvalidFirstByteRejected) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(1);
+  bus.register_device(&device);
+
+  // First byte must be '*' (0x2A); '#' is invalid
+  bus.feed("#01X\xCRC\r");
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(AesgiRs485ParseTest, BadCrcRejected) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(1);
+  bus.register_device(&device);
+
+  std::string frame = make_frame(1, "X");
+  frame[frame.size() - 2] ^= 0xFF;  // corrupt CRC
+  bus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(AesgiRs485ParseTest, UnknownAddressNotDispatched) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(5);
+  bus.register_device(&device);
+
+  std::string frame = make_frame(3, "X");  // address 3, device expects 5
+  bus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(AesgiRs485ParseTest, TwoFramesDispatchedTwice) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(29);
+  bus.register_device(&device);
+
+  bus.feed(REAL_STATUS_FRAME);
+  bus.feed(REAL_STATUS_FRAME);
+
+  EXPECT_EQ(device.call_count, 2);
+}
+
+TEST(AesgiRs485ParseTest, NoRegisteredDeviceDoesNotCrash) {
+  TestableAesgiRs485 bus;
+  bus.feed(make_frame(1, "X"));
+}
+
+TEST(AesgiRs485ParseTest, FrameTooShortRejected) {
+  TestableAesgiRs485 bus;
+  MockAesgiRs485Device device;
+  device.set_address(1);
+  bus.register_device(&device);
+
+  // Frame with only 4 bytes (minimum is 5): *01<crc>\r -- no content, too short
+  std::string frame = "*01";
+  uint8_t crc = compute_chksum(frame);
+  frame += static_cast<char>(crc);
+  frame += '\r';  // frame_len = 5, but check is frame_len < 5 so this might pass...
+  // Actually frame_len = 5 is the boundary: "if (frame_len < 5) return false"
+  // With 4 bytes before \r: frame_len = 5, which is NOT < 5, so it proceeds to CRC check.
+  // This is fine, just verifying no crash.
+  bus.feed(frame);
+}
+
+}  // namespace esphome::aesgi_rs485::testing

--- a/tests/components/aesgi_rs485/aesgi_rs485_test.cpp
+++ b/tests/components/aesgi_rs485/aesgi_rs485_test.cpp
@@ -5,8 +5,7 @@ namespace esphome::aesgi_rs485::testing {
 
 // Real captured response from esp8266-inverter-emulator.yaml (address 29):
 // *290   0  20.0  0.00     0 235.1  0.01     1  50     44 \xD9\r
-static const std::string REAL_STATUS_FRAME =
-    "*290   0  20.0  0.00     0 235.1  0.01     1  50     44 \xD9\r";
+static const std::string REAL_STATUS_FRAME = "*290   0  20.0  0.00     0 235.1  0.01     1  50     44 \xD9\r";
 
 // verify_checksum_ special case: remote_crc == 0x20 (space) and (crc + 0x20) & 0xFF == '\r'
 // This handles a quirk where the CRC byte is a space followed by a carriage-return-like value.

--- a/tests/components/aesgi_rs485/common.h
+++ b/tests/components/aesgi_rs485/common.h
@@ -1,0 +1,57 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "esphome/components/aesgi_rs485/aesgi_rs485.h"
+
+namespace esphome::aesgi_rs485::testing {
+
+class MockAesgiRs485Device : public AesgiRs485Device {
+ public:
+  std::string received_data;
+  int call_count{0};
+
+  void on_aesgi_rs485_data(const std::string &data) override {
+    received_data = data;
+    call_count++;
+  }
+};
+
+class TestableAesgiRs485 : public AesgiRs485 {
+ public:
+  void loop() override {}
+  using AesgiRs485::parse_aesgi_rs485_byte_;
+  using AesgiRs485::verify_checksum_;
+
+  bool feed(const std::string &frame) {
+    bool result = false;
+    for (char c : frame)
+      result = parse_aesgi_rs485_byte_(static_cast<uint8_t>(c));
+    return result;
+  }
+};
+
+// chksum: sum of all bytes mod 256
+inline uint8_t compute_chksum(const std::string &data) {
+  uint8_t sum = 0;
+  for (char c : data)
+    sum += static_cast<uint8_t>(c);
+  return sum;
+}
+
+// Build a valid aesgi_rs485 frame with correct checksum.
+// Format: * <addr_hi> <addr_lo> <content> <crc> \r
+// addr is 2-digit decimal (address 1..32).
+// content should include any trailing delimiter if present in the real protocol.
+inline std::string make_frame(uint8_t address, const std::string &content) {
+  std::string frame = "*";
+  frame += static_cast<char>('0' + (address / 10));
+  frame += static_cast<char>('0' + (address % 10));
+  frame += content;
+  uint8_t crc = compute_chksum(frame);
+  frame += static_cast<char>(crc);
+  frame += '\r';
+  return frame;
+}
+
+}  // namespace esphome::aesgi_rs485::testing

--- a/tests/components/aesgi_rs485/common.h
+++ b/tests/components/aesgi_rs485/common.h
@@ -25,8 +25,11 @@ class TestableAesgiRs485 : public AesgiRs485 {
 
   bool feed(const std::string &frame) {
     bool result = false;
-    for (char c : frame)
+    for (char c : frame) {
       result = parse_aesgi_rs485_byte_(static_cast<uint8_t>(c));
+      if (!result)
+        rx_buffer_.clear();
+    }
     return result;
   }
 };

--- a/tests/components/aesgi_rs485/test.host.yaml
+++ b/tests/components/aesgi_rs485/test.host.yaml
@@ -1,0 +1,7 @@
+uart:
+  - id: uart_bus
+    baud_rate: 9600
+
+aesgi_rs485:
+  - id: rs485_bus
+    uart_id: uart_bus


### PR DESCRIPTION
## Summary

Add `tests/components/aesgi_rs485/` with 11 unit tests for the RS485 transport layer.

## Coverage

- `verify_checksum_`: normal match, normal mismatch, special-case tolerance (remote_crc == 0x20 with adjusted computed value), no false positive
- Frame parsing: valid synthetic frame, real captured status frame (address 29), invalid first byte rejection, bad CRC rejection, unknown address not dispatched, two consecutive frames, no registered device (no crash), frame at minimum length boundary

## Test plan

- [ ] `esphome compile tests/components/aesgi_rs485/test.host.yaml`
- [ ] Run gtest binary from host build