### PR TITLE
Fix battery current limit parsed as int instead of float

### DIFF
--- a/components/aesgi/aesgi.cpp
+++ b/components/aesgi/aesgi.cpp
@@ -227,16 +227,16 @@ void Aesgi::on_battery_current_limit_data_(const std::string &data) {
 
   ESP_LOGI(TAG, "Battery current limit frame received (%zu bytes)", data.size());
 
-  int current_limit;
+  float current_limit;
 
   // *29S 11.5 \xED\r
-  if (sscanf(data.c_str(), "*%*s %d", &current_limit) != 1) {  // NOLINT
+  if (sscanf(data.c_str(), "*%*s %f", &current_limit) != 1) {  // NOLINT
     ESP_LOGE(TAG, "Parsing battery current limit response failed: %s", data.c_str());
     return;
   }
 
-  this->publish_state_(this->battery_current_limit_sensor_, (float) current_limit);
-  this->publish_state_(this->battery_current_limit_number_, (float) current_limit);
+  this->publish_state_(this->battery_current_limit_sensor_, current_limit);
+  this->publish_state_(this->battery_current_limit_number_, current_limit);
 }
 
 void Aesgi::on_operation_mode_data_(const std::string &data) {

--- a/tests/components/aesgi/aesgi_test.cpp
+++ b/tests/components/aesgi/aesgi_test.cpp
@@ -270,9 +270,8 @@ class AesgiBatteryCurrentLimitTest : public ::testing::Test {
 };
 
 TEST_F(AesgiBatteryCurrentLimitTest, BatteryCurrentLimit) {
-  // sscanf %d truncates 11.5 to 11
   aesgi_.on_battery_current_limit_data_(BATTERY_CURRENT_LIMIT_RESPONSE);
-  EXPECT_FLOAT_EQ(battery_current_limit_.state, 11.0f);
+  EXPECT_NEAR(battery_current_limit_.state, 11.5f, 0.05f);
 }
 
 TEST_F(AesgiBatteryCurrentLimitTest, NullSensorSafe) {


### PR DESCRIPTION
## Summary

The `#xxS` response frame contains a float value (e.g. `*29S 11.5`), but `on_battery_current_limit_data_` was parsing it with `%d` (int), silently truncating the decimal part.

- Change `int current_limit` → `float current_limit`
- Change `sscanf` format `%d` → `%f`
- Remove redundant `(float)` cast on `publish_state_` calls