### PR TITLE
Enable scanf float support for ESP8266

### DIFF
--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -15,6 +15,7 @@ esphome:
 
 esp8266:
   board: d1_mini
+  enable_scanf_float: true
 
 external_components:
   - source: ${external_components_source}


### PR DESCRIPTION
## Summary

Recent ESP8266 Arduino framework versions require `enable_scanf_float: true` to parse floating-point values via `sscanf`. Without it, `%f` format specifiers silently fail, which affects parsing of all float sensor values (e.g. voltages, currents, frequencies).