### PR TITLE
Fix format specifier for size_t in frame length warning

### DIFF
--- a/components/aesgi_rs485/aesgi_rs485.cpp
+++ b/components/aesgi_rs485/aesgi_rs485.cpp
@@ -66,7 +66,7 @@ bool AesgiRs485::parse_aesgi_rs485_byte_(uint8_t byte) {
   size_t frame_len = at + 1;
 
   if (frame_len < 5) {
-    ESP_LOGW(TAG, "Frame too short: %d", frame_len);
+    ESP_LOGW(TAG, "Frame too short: %zu", frame_len);
     return false;
   }
 


### PR DESCRIPTION
## Summary

`frame_len` is of type `size_t` (`long unsigned int` on 64-bit platforms), but the log format used `%d` (expects `int`), causing a `-Wformat=` compiler warning. Fixed by using `%zu`.