### PR TITLE
Add flow_control_pin support to aesgi_rs485

### DIFF
--- a/components/aesgi_rs485/__init__.py
+++ b/components/aesgi_rs485/__init__.py
@@ -1,7 +1,8 @@
+from esphome import pins
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ADDRESS, CONF_ID
+from esphome.const import CONF_ADDRESS, CONF_FLOW_CONTROL_PIN, CONF_ID
 
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@syssi"]
@@ -22,6 +23,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_RX_TIMEOUT, default="50ms"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -37,6 +39,10 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
 
     cg.add(var.set_rx_timeout(config[CONF_RX_TIMEOUT]))
+
+    if CONF_FLOW_CONTROL_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
+        cg.add(var.set_flow_control_pin(pin))
 
 
 def aesgi_rs485_device_schema(default_address):

--- a/components/aesgi_rs485/aesgi_rs485.cpp
+++ b/components/aesgi_rs485/aesgi_rs485.cpp
@@ -7,6 +7,13 @@ namespace esphome::aesgi_rs485 {
 
 static const char *const TAG = "aesgi_rs485";
 
+void AesgiRs485::setup() {
+  if (this->flow_control_pin_ != nullptr) {
+    this->flow_control_pin_->setup();
+    this->flow_control_pin_->digital_write(false);
+  }
+}
+
 void AesgiRs485::loop() {
   const uint32_t now = millis();
   if (now - this->last_aesgi_rs485_byte_ > this->rx_timeout_) {
@@ -97,6 +104,7 @@ bool AesgiRs485::parse_aesgi_rs485_byte_(uint8_t byte) {
 void AesgiRs485::dump_config() {
   ESP_LOGCONFIG(TAG, "AesgiRs485:");
   ESP_LOGCONFIG(TAG, "  RX timeout: %d ms", this->rx_timeout_);
+  LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
 }
 float AesgiRs485::get_setup_priority() const {
   // After UART bus
@@ -126,8 +134,12 @@ void AesgiRs485::send(uint8_t address, uint8_t command, const std::string &value
 
   frame[frame_len - 1] = '\r';
 
+  if (this->flow_control_pin_ != nullptr)
+    this->flow_control_pin_->digital_write(true);
   this->write_array(frame.data(), frame_len);
   this->flush();
+  if (this->flow_control_pin_ != nullptr)
+    this->flow_control_pin_->digital_write(false);
 }
 
 void AesgiRs485::send_broadcast(uint8_t command, const std::string &value) {
@@ -149,8 +161,12 @@ void AesgiRs485::send_broadcast(uint8_t command, const std::string &value) {
 
   frame[frame_len - 1] = '\r';
 
+  if (this->flow_control_pin_ != nullptr)
+    this->flow_control_pin_->digital_write(true);
   this->write_array(frame.data(), frame_len);
   this->flush();
+  if (this->flow_control_pin_ != nullptr)
+    this->flow_control_pin_->digital_write(false);
 }
 
 }  // namespace esphome::aesgi_rs485

--- a/components/aesgi_rs485/aesgi_rs485.h
+++ b/components/aesgi_rs485/aesgi_rs485.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/gpio.h"
 #include "esphome/components/uart/uart.h"
 
 namespace esphome::aesgi_rs485 {
@@ -11,6 +12,7 @@ class AesgiRs485 : public uart::UARTDevice, public Component {
  public:
   AesgiRs485() = default;
 
+  void setup() override;
   void loop() override;
 
   void dump_config() override;
@@ -22,6 +24,7 @@ class AesgiRs485 : public uart::UARTDevice, public Component {
   void send(uint8_t address, uint8_t command, const std::string &value = "");
   void send_broadcast(uint8_t command, const std::string &value = "");
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
+  void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
 
  protected:
   bool parse_aesgi_rs485_byte_(uint8_t byte);
@@ -34,6 +37,7 @@ class AesgiRs485 : public uart::UARTDevice, public Component {
     return computed_crc == remote_crc;
   }
 
+  GPIOPin *flow_control_pin_{nullptr};
   std::vector<uint8_t> rx_buffer_;
   uint16_t rx_timeout_{50};
   uint32_t last_aesgi_rs485_byte_{0};

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -58,6 +58,7 @@ aesgi_rs485:
   - id: bus0
     uart_id: uart_0
     rx_timeout: 250ms
+    # flow_control_pin: GPIO12
 
 aesgi:
   - id: inverter0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -58,6 +58,7 @@ aesgi_rs485:
   - id: bus0
     uart_id: uart_0
     rx_timeout: 250ms
+    # flow_control_pin: GPIO12
 
 aesgi:
   - id: inverter0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -56,6 +56,7 @@ aesgi_rs485:
   - id: bus0
     uart_id: uart_0
     rx_timeout: 250ms
+    # flow_control_pin: GPIO12
 
 aesgi:
   - id: inverter0


### PR DESCRIPTION
## Summary

- Adds optional `flow_control_pin` to `aesgi_rs485` for RS485 half-duplex transceivers that require explicit TX/RX direction switching via GPIO
- Pin is driven high before writing, low after flush, in both `send()` and `send_broadcast()`
- Pin is initialized low in `setup()` and shown in `dump_config()`
- Added commented example `# flow_control_pin: GPIO12` to all three YAML examples

## Test plan

- [ ] Configure with a MAX485-type transceiver and verify direction switching
- [ ] Verify normal operation without `flow_control_pin` is unaffected