### PR TITLE
Replace magic number 7 with COMMAND_QUEUE_SIZE

### DIFF
--- a/components/aesgi/aesgi.cpp
+++ b/components/aesgi/aesgi.cpp
@@ -17,8 +17,7 @@ static const uint8_t AESGI_COMMAND_ERROR_HISTORY = 'F';
 static const uint8_t AESGI_COMMAND_BATTERY_CURRENT_LIMIT = 'S';
 static const uint8_t AESGI_COMMAND_OPERATION_MODE = 'B';
 
-static const uint8_t AESGI_COMMAND_QUEUE_SIZE = 7;
-static const uint8_t AESGI_COMMAND_QUEUE[AESGI_COMMAND_QUEUE_SIZE] = {
+static const uint8_t AESGI_COMMAND_QUEUE[Aesgi::COMMAND_QUEUE_SIZE] = {
     AESGI_COMMAND_STATUS,
     AESGI_COMMAND_DEVICE_TYPE,
     AESGI_COMMAND_OUTPUT_POWER_THROTTLE,
@@ -79,8 +78,8 @@ void Aesgi::on_aesgi_rs485_data(const std::string &data) {
   }
 
   // Send next command after each received frame
-  if (this->next_command_ < AESGI_COMMAND_QUEUE_SIZE) {
-    this->send(AESGI_COMMAND_QUEUE[this->next_command_++ % AESGI_COMMAND_QUEUE_SIZE]);
+  if (this->next_command_ < COMMAND_QUEUE_SIZE) {
+    this->send(AESGI_COMMAND_QUEUE[this->next_command_++ % COMMAND_QUEUE_SIZE]);
   }
 }
 
@@ -289,15 +288,15 @@ void Aesgi::update() {
   this->track_online_status_();
 
   // Loop through all commands if connected
-  if (this->next_command_ != AESGI_COMMAND_QUEUE_SIZE && this->no_response_count_ < MAX_NO_RESPONSE_COUNT) {
+  if (this->next_command_ != COMMAND_QUEUE_SIZE && this->no_response_count_ < MAX_NO_RESPONSE_COUNT) {
     ESP_LOGW(TAG,
              "Command queue (%d of %d) was not completely processed. "
              "Please increase the update_interval if you see this warning frequently",
-             this->next_command_ + 1, AESGI_COMMAND_QUEUE_SIZE);
+             this->next_command_ + 1, COMMAND_QUEUE_SIZE);
   }
   this->next_command_ = 0;
 
-  this->send(AESGI_COMMAND_QUEUE[this->next_command_++ % AESGI_COMMAND_QUEUE_SIZE]);
+  this->send(AESGI_COMMAND_QUEUE[this->next_command_++ % COMMAND_QUEUE_SIZE]);
 }
 
 void Aesgi::track_online_status_() {

--- a/components/aesgi/aesgi.h
+++ b/components/aesgi/aesgi.h
@@ -103,7 +103,7 @@ class Aesgi : public PollingComponent, public aesgi_rs485::AesgiRs485Device {
 
   void update() override;
 
- static constexpr uint8_t COMMAND_QUEUE_SIZE = 7;
+  static constexpr uint8_t COMMAND_QUEUE_SIZE = 7;
 
  protected:
   binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};

--- a/components/aesgi/aesgi.h
+++ b/components/aesgi/aesgi.h
@@ -103,6 +103,8 @@ class Aesgi : public PollingComponent, public aesgi_rs485::AesgiRs485Device {
 
   void update() override;
 
+ static constexpr uint8_t COMMAND_QUEUE_SIZE = 7;
+
  protected:
   binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
 
@@ -144,8 +146,6 @@ class Aesgi : public PollingComponent, public aesgi_rs485::AesgiRs485Device {
   text_sensor::TextSensor *operation_mode_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
   text_sensor::TextSensor *device_type_text_sensor_{nullptr};
-
-  static constexpr uint8_t COMMAND_QUEUE_SIZE = 7;
 
   uint8_t no_response_count_{0};
   uint8_t next_command_{COMMAND_QUEUE_SIZE};

--- a/components/aesgi/aesgi.h
+++ b/components/aesgi/aesgi.h
@@ -145,8 +145,10 @@ class Aesgi : public PollingComponent, public aesgi_rs485::AesgiRs485Device {
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
   text_sensor::TextSensor *device_type_text_sensor_{nullptr};
 
+  static constexpr uint8_t COMMAND_QUEUE_SIZE = 7;
+
   uint8_t no_response_count_{0};
-  uint8_t next_command_{7};
+  uint8_t next_command_{COMMAND_QUEUE_SIZE};
 
   void on_auto_test_data_(const std::string &data);
   void on_status_data_(const std::string &data);


### PR DESCRIPTION
## Summary

- Removes the file-static `AESGI_COMMAND_QUEUE_SIZE = 7` constant from `aesgi.cpp`
- Adds `static constexpr uint8_t COMMAND_QUEUE_SIZE = 7` to the `Aesgi` class
- `next_command_{COMMAND_QUEUE_SIZE}` replaces the literal `{7}` in the member initializer
- All usages in `update()` and `on_aesgi_rs485_data()` reference the named constant